### PR TITLE
show messaging when no matches were found

### DIFF
--- a/analysis-tool-front-end/src/components/MainMenu.js
+++ b/analysis-tool-front-end/src/components/MainMenu.js
@@ -62,6 +62,8 @@ export default function MainMenu(props) {
         </h2>
       </div>
 
+      {!matches.length && <div className="px-5 py-3 col-span-12">No matches found.</div>}
+
       <div className="grid grid-cols-12">
         {matches.map((match) => {
           return (


### PR DESCRIPTION
Shows some simple messaging when no matches were returned from the `/match` endpoint

![image](https://github.com/user-attachments/assets/721ea7b0-42b2-44b5-b7e5-83787ccdc068)
