### PR TITLE
reduce the size of the process button

### DIFF
--- a/analysis-tool-front-end/src/components/colorPicker.module.css
+++ b/analysis-tool-front-end/src/components/colorPicker.module.css
@@ -43,14 +43,13 @@ h5 {
 
 /* Defines the style of out next button, located in the process div. */
 .NextButtonColour {
-  width: 100%;
-  height: 100%;
   text-align: center;
   background:#006F3A;
   color: white;
   border: 3px solid #006F3A;
   border-radius: 10px;
-  font-size: 3rem;
+  padding: 12px;
+  font-size: 16px;
   font-weight: bold;
   cursor: pointer;
 }
@@ -115,9 +114,7 @@ h5 {
   position: absolute;
   top: 60%;
   left: 110%;
-  width: 30%;
-  height: 20%;
-  border: 3px solid #006F3A;    
+  margin-top: 12px;
   border-radius: 20px;
   text-align: center;
 }


### PR DESCRIPTION
Reduces the dimensions of the process button on the player selection screen:

Before:
![process button before](https://github.com/user-attachments/assets/44569c95-c624-4c63-adf5-02a6e8829c5f)

After:
![process button after](https://github.com/user-attachments/assets/d4356d91-bda5-47ed-b073-e80b1fc1ef1f)
